### PR TITLE
Ensure needed tags are present.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "npm run lint && npm run spec"
   },
   "dependencies": {
-    "adana-analyze": "^0.1.0"
+    "adana-analyze": "^0.1.1"
   },
   "devDependencies": {
     "babel-cli": "^6.0.2",

--- a/src/lcov.js
+++ b/src/lcov.js
@@ -35,7 +35,11 @@ export function branches(data) {
 export default function lcov(coverage) {
   const files = Object.keys(coverage);
   return files.map(file => {
-    const t = tags(coverage[file].locations);
+    const t = tags(coverage[file].locations, [
+      'line',
+      'function',
+      'branch',
+    ]);
     return [
       `TN:`,
       `SF: ${file}`,

--- a/test/spec/lcov.spec.js
+++ b/test/spec/lcov.spec.js
@@ -7,7 +7,17 @@ import lcov from '../../src/lcov';
 const fixture = path.join(__dirname, '/../fixture/coverage.json');
 const data = JSON.parse(readFileSync(fixture, 'utf8'));
 
-it('should filter', () => {
+it('should output something', () => {
   const result = lcov(data);
+  expect(result).to.contain('SF: src/instrumenter.js');
+});
+
+it('should work with no branches', () => {
+  const locs = data['src/instrumenter.js'].locations.filter(loc => {
+    return loc.tags.indexOf('branch') === -1;
+  });
+  const result = lcov({
+    'src/instrumenter.js': { locations: locs },
+  });
   expect(result).to.contain('SF: src/instrumenter.js');
 });


### PR DESCRIPTION
The `analyze` family of functions requires an array of locations to be passed; if tag data isn't present then this borks things. By specifying the tags that are required a valid property will be available to send for analysis.

See:
- https://github.com/adana-coverage/adana-analyze/pull/3
