### PR TITLE
Ignore locations with the `ignore` tag.

### DIFF
--- a/src/lcov.js
+++ b/src/lcov.js
@@ -35,7 +35,10 @@ export function branches(data) {
 export default function lcov(coverage) {
   const files = Object.keys(coverage);
   return files.map(file => {
-    const t = tags(coverage[file].locations, [
+    const locations = coverage[file].locations.filter(({tags}) => {
+      return tags.indexOf('ignore') === -1;
+    });
+    const t = tags(locations, [
       'line',
       'function',
       'branch',


### PR DESCRIPTION
Sometimes you don't want to have certain tags in your output. Might be handy to have a flag for what tags to ignore, but this seems like a sane default.
